### PR TITLE
Update esp-aws-iot submodule pointer for transport test

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,7 +10,7 @@ dependencies:
       url: "https://github.com/FreeRTOS/FreeRTOS-Libraries-Integration-Tests"
       path: "components/FreeRTOS-Libraries-Integration-Tests/FreeRTOS-Libraries-Integration-Tests"
   - name: "esp-aws-iot"
-    version: "202406.01-LTS-release"
+    version: "cd1bd3b654f7cf6393bb92100bb7916cf9152c06"
     repository:
       type: "git"
       url: "https://github.com/espressif/esp-aws-iot.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Update esp-aws-iot to include this commit https://github.com/espressif/esp-aws-iot/commit/fed617c47baf27b07b7522751e6e071bd689d5ae for transport interface test.

More information in this PR https://github.com/espressif/esp-aws-iot/pull/228


Test Steps
-----------
Test
Run the [transport interface test](https://github.com/FreeRTOS/FreeRTOS-Libraries-Integration-Tests/tree/main/src/transport_interface) the following test cases should has no error.
```
TEST(Full_TransportInterfaceTest, TransportRecv_NetworkContextNullPtr)./components/FreeRTOS-Libraries-Integration-Tests/FreeRTOS-Libraries-Integration-Tests/src/transport_interface/transport_interface_test.c:865::FAIL: Expected 0 to be less than 0. Transport interface recv with NULL network context pointer should return negative value.

TEST(Full_TransportInterfaceTest, TransportRecv_BufferNullPtr)./components/FreeRTOS-Libraries-Integration-Tests/FreeRTOS-Libraries-Integration-Tests/src/transport_interface/transport_interface_test.c:886::FAIL: Expected 0 to be less than 0. Transport interface recv with NULL buffer pointer should return negative value.

TEST(Full_TransportInterfaceTest, TransportRecv_ZeroByteToRecv)./components/FreeRTOS-Libraries-Integration-Tests/FreeRTOS-Libraries-Integration-Tests/src/transport_interface/transport_interface_test.c:905::FAIL: Expected 0 to be less than 0. Transport interface recv with zero byte to recv should return negative value.
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
