### PR TITLE
Subscribe to topic notify-next

### DIFF
--- a/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
+++ b/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
@@ -1392,6 +1392,19 @@ static void prvOTADemoTask( void * pvParam )
             vTaskDelay( pdMS_TO_TICKS( 100 ) );
         }
 
+        // Subscribe to notify-next
+        char jobNotifyTopic[JOBS_API_MAX_LENGTH(strlen(otademoconfigCLIENT_IDENTIFIER))];
+        size_t jobNotifyTopicLen = 0;
+
+        JobsStatus_t status = Jobs_GetTopic( jobNotifyTopic,
+                                             sizeof(jobNotifyTopic),
+                                             otademoconfigCLIENT_IDENTIFIER,
+                                             strlen(otademoconfigCLIENT_IDENTIFIER),
+                                             JobsNextJobChanged,
+                                             &jobNotifyTopicLen);
+
+        prvMQTTSubscribe( jobNotifyTopic, (uint16_t) jobNotifyTopicLen, 1 );
+
         while( otaAgentState != OtaAgentStateStopped )
         {
             processOTAEvents();


### PR DESCRIPTION
<!--- Title -->
Fix: Add subscription to notify-next topic for OTA job pickup
 
Description
-----------
<!--- Describe your changes in detail -->

This change re-introduces the subscription to the `notify-next` topic. In a previous re-structuring, this essential topic subscription was inadvertently removed. This topic is crucial for the device to be notified of and pick up new OTA jobs that are created after the device has already connected to the AWS IoT Core. Without this subscription, new OTA jobs initiated post-connection were not being detected by the device.

Test Steps
-----------
1. Flash a device with the updated firmware containing this change.
2. Connect the device to AWS IoT Core.
3. After the device has successfully connected, create a new OTA update job targeting this device via AWS IoT Jobs.
4. Verify that the device receives the job notification and proceeds to download and apply the OTA update.
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
[Issue 117](https://github.com/FreeRTOS/iot-reference-esp32/issues/117)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
