### PR TITLE
Remove "expectedVersion" field from job update message

### DIFF
--- a/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
+++ b/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
@@ -1038,11 +1038,10 @@ static bool sendSuccessMessage( void )
          * Creating the message which contains the status of OTA job.
          * It will be published on the topic created in the previous step.
          */
-        size_t messageBufferLength = Jobs_UpdateMsg( Succeeded,
-                                                     "2",
-                                                     1U,
-                                                     messageBuffer,
-                                                     UPDATE_JOB_MSG_LENGTH );
+        size_t messageBufferLength = snprintf( messageBuffer,
+                                               UPDATE_JOB_MSG_LENGTH,
+                                               "%sSUCCEEDED\"}",
+                                               JOBS_API_STATUS );
 
         result = prvMQTTPublish( topicBuffer,
                                  topicBufferLength,


### PR DESCRIPTION
<!--- Title -->
Fix: Remove hardcoded expectedVersion from OTA success message to prevent re-download loop

Description
-----------
This change addresses an issue where the device would continuously re-download an OTA package without success. The root cause was a hardcoded `expectedVersion` ("2") in the OTA success message sent to AWS IoT Jobs. "The expectedVersion field wasn't updating, resulting in a version mismatch that caused the job to neither succeed nor fail. The job status remained 'running', which triggered multiple consecutive OTA downloads.

This commit removes the `expectedVersion` from the success message payload by directly formatting the JSON string using `snprintf` instead of `Jobs_UpdateMsg`. This prevents the mismatch or incorrect versioning that led to the re-download loop.

This resolves issue #120.

Test Steps
-----------
1. Set up the ESP32 device for an OTA update via MQTT as per the demo's original configuration (prior to this change).
2. Trigger an OTA update with a new firmware version.
3. **Observe (Before Change):** The device might download the firmware, apply it, but then potentially re-download the same firmware package repeatedly because the `expectedVersion` in the success message was hardcoded and might not match the actual next expected version from the perspective of the OTA service or job document.
4. Apply the changes from this Pull Request to the `ota_over_mqtt_demo.c` file.
5. Re-flash the device and trigger the same OTA update again.
6. **Observe (After Change):** The device should download the firmware, apply it, and send a success message. It should then remain in a stable state, successfully updated, and not attempt to re-download the same package. The OTA job should be marked as "SUCCEEDED" in AWS IoT Jobs.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
issue #[120](https://github.com/FreeRTOS/iot-reference-esp32/issues/120).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
